### PR TITLE
Proper signal to pass to shutdown redis

### DIFF
--- a/support/redis-server
+++ b/support/redis-server
@@ -40,7 +40,7 @@ start() {
 
 stop() {
     echo -n $"Stopping $prog: "
-    killproc $prog -QUIT
+    killproc $prog -TERM
     retval=$?
     echo
     [ $retval -eq 0 ] && rm -f $lockfile


### PR DESCRIPTION
TERM asks redis to commit changes to disk and shutdown cleanly. I think QUIT isn't a valid signal. This has been bothering me for quite a while now. 
