### PR TITLE
Add boots for Autoconf 2.69, Ruby 2.1.1, Rubygems 2.2.2

### DIFF
--- a/boots/autoconf.sh
+++ b/boots/autoconf.sh
@@ -1,0 +1,13 @@
+#! /usr/bin/env bash
+
+VERSION=2.69
+
+cd /usr/src
+sudo wget http://ftp.gnu.org/gnu/autoconf/autoconf-${VERSION}.tar.gz
+sudo tar -xzvf autoconf-${VERSION}.tar.gz
+cd autoconf-${VERSION}
+sudo ./configure PREFIX=/usr
+sudo make
+sudo make install
+sudo make installcheck
+/usr/bin/autoconf --version

--- a/boots/autoconf.sh
+++ b/boots/autoconf.sh
@@ -1,12 +1,14 @@
 #! /usr/bin/env bash
 
+set -ex
+
 VERSION=2.69
 
 cd /usr/src
 sudo wget http://ftp.gnu.org/gnu/autoconf/autoconf-${VERSION}.tar.gz
 sudo tar -xzvf autoconf-${VERSION}.tar.gz
 cd autoconf-${VERSION}
-sudo ./configure PREFIX=/usr
+sudo ./configure --prefix=/usr
 sudo make
 sudo make install
 sudo make installcheck

--- a/boots/ruby.sh
+++ b/boots/ruby.sh
@@ -1,17 +1,24 @@
 #! /usr/bin/env bash
-
 set -xe
 
 # ruby 2.1.0
 RUBY_VERSION=2.1.1
+FOLDER_NAME="ruby-${RUBY_VERSION}"
+TAR_FILE="${FOLDER_NAME}.tar.gz"
 cd /usr/src
-sudo wget ftp://ftp.ruby-lang.org/pub/ruby/2.1/ruby-$RUBY_VERSION.tar.gz 
-sudo tar -zxvf ruby-$RUBY_VERSION.tar.gz
-cd ruby-$RUBY_VERSION
+
+if [ ! -d "${FOLDER_NAME}" ]; then
+  if [ ! -f "${TAR_FILE}" ]; then
+    sudo wget ftp://ftp.ruby-lang.org/pub/ruby/2.1/${TAR_FILE}
+  fi
+  sudo tar -zxvf ${TAR_FILE}
+fi
+
+cd ${FOLDER_NAME}
 sudo autoconf
-sudo ./configure PREFIX=/usr
+sudo ./configure --prefix=/usr
 sudo make
 sudo make install
 /usr/bin/ruby --version
- 
-./bootstrap rubygems
+
+echo "Great! Ruby $(/usr/bin/ruby --version) is all installed. Now bootstrap RubyGems to finish up."

--- a/boots/ruby.sh
+++ b/boots/ruby.sh
@@ -1,0 +1,17 @@
+#! /usr/bin/env bash
+
+set -xe
+
+# ruby 2.1.0
+RUBY_VERSION=2.1.1
+cd /usr/src
+sudo wget ftp://ftp.ruby-lang.org/pub/ruby/2.1/ruby-$RUBY_VERSION.tar.gz 
+sudo tar -zxvf ruby-$RUBY_VERSION.tar.gz
+cd ruby-$RUBY_VERSION
+sudo autoconf
+sudo ./configure PREFIX=/usr
+sudo make
+sudo make install
+/usr/bin/ruby --version
+ 
+./bootstrap rubygems

--- a/boots/rubygems.sh
+++ b/boots/rubygems.sh
@@ -1,0 +1,12 @@
+#! /usr/bin/env bash
+
+set -xe
+
+# RubyGems
+RUBYGEMS_VERSION=2.2.2
+cd /usr/src
+sudo wget http://production.cf.rubygems.org/rubygems/rubygems-$RUBYGEMS_VERSION.tgz
+sudo tar zxvf rubygems-$RUBYGEMS_VERSION.tgz
+cd rubygems-$RUBYGEMS_VERSION
+sudo /usr/bin/ruby setup.rb
+/usr/bin/gem --version


### PR DESCRIPTION
Currently eff'd up. Ruby 2.1.1 requires autoconf 2.69 but autoconf 2.69 is installing into `/usr/local` instead of `/usr` which sucks because I want it to be global.
